### PR TITLE
feat: uikit h5 vue 10.3.0-alpha.2

### DIFF
--- a/nim-kit-vue-ui-h5/package.json
+++ b/nim-kit-vue-ui-h5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "im-kit-vue-ui-h5",
-  "version": "10.3.0-alpha.1",
+  "version": "10.3.0-alpha.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/nim-kit-vue-ui-h5/src/components/NEUIKit/Chat/message/message-forward.vue
+++ b/nim-kit-vue-ui-h5/src/components/NEUIKit/Chat/message/message-forward.vue
@@ -305,6 +305,17 @@ import { toast } from "../../utils/toast";
 import type { V2NIMMessageForUI } from "@xkit-yx/im-store-v2/dist/types/src/types";
 import { sendMergedForwardMessage } from "./merged-forward/utils";
 import { friendGroupByPy } from "../../utils/friend";
+import emitter from "../../utils/eventBus";
+import { events } from "../../utils/constants";
+
+// 双 rAF 后触发滚动到底部，确保 Vue 重渲染 + 浏览器 layout 完成后再滚动
+const scrollChatToBottom = () => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      emitter.emit(events.ON_SCROLL_BOTTOM);
+    });
+  });
+};
 
 const RECENT_FORWARDS_KEY = "nim_recent_forwards_v2";
 const MAX_RECENT_FORWARDS = 5;
@@ -623,6 +634,20 @@ const handleForwardConfirm = (forwardComment: string) => {
             name: target.name,
           }, myAccountId.value);
         });
+        // 若目标包含当前会话，转发消息会出现在当前聊天页，需滚动到底部展示新消息
+        if (
+          targets.some((target) => {
+            const convId = nim.V2NIMConversationIdUtil[
+              target.type ===
+              V2NIMConst.V2NIMConversationType.V2NIM_CONVERSATION_TYPE_P2P
+                ? "p2pConversationId"
+                : "teamConversationId"
+            ](target.id);
+            return convId === conversationId.value;
+          })
+        ) {
+          scrollChatToBottom();
+        }
       })
       .catch(() => {
         toast.info(t("forwardFailedText"));
@@ -677,6 +702,10 @@ const handleForwardConfirm = (forwardComment: string) => {
             : "team",
         name: "",
       }, myAccountId.value);
+      // 转发到当前会话时，新消息会出现在当前聊天页，需滚动到底部展示
+      if (forwardConversationId === conversationId.value) {
+        scrollChatToBottom();
+      }
     })
     .catch(() => {
       toast.info(t("forwardFailedText"));

--- a/nim-kit-vue-ui-h5/src/components/NEUIKit/Chat/message/nav-bar.vue
+++ b/nim-kit-vue-ui-h5/src/components/NEUIKit/Chat/message/nav-bar.vue
@@ -4,7 +4,6 @@
       class="nav-bar-wrapper"
       :style="{
         backgroundColor: backgroundColor || '#ffffff',
-        backgroundImage: `url(${title})`,
         height: '50px',
         alignItems: 'center',
       }"

--- a/nim-kit-vue-ui-h5/src/components/NEUIKit/CommonComponents/Modal.vue
+++ b/nim-kit-vue-ui-h5/src/components/NEUIKit/CommonComponents/Modal.vue
@@ -1,19 +1,21 @@
 <template>
-  <div class="modal" v-if="visible">
-    <div class="mask" @click="handleMaskClick"></div>
-    <div class="content">
-      <div class="title">{{ title }}</div>
-      <div class="slot-content"><slot></slot></div>
-      <div class="buttons">
-        <div v-if="cancelText" class="button cancel" @click="handleCancelClick">
-          {{ cancelText }}
-        </div>
-        <div class="button confirm" :class="{ 'full-width': !cancelText }" @click="handleConfirmClick">
-          {{ confirmText }}
+  <Teleport to="body">
+    <div class="modal" v-if="visible">
+      <div class="mask" @click="handleMaskClick"></div>
+      <div class="content">
+        <div class="title">{{ title }}</div>
+        <div class="slot-content"><slot></slot></div>
+        <div class="buttons">
+          <div v-if="cancelText" class="button cancel" @click="handleCancelClick">
+            {{ cancelText }}
+          </div>
+          <div class="button confirm" :class="{ 'full-width': !cancelText }" @click="handleConfirmClick">
+            {{ confirmText }}
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </Teleport>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
- Modal.vue 包裹 Teleport to body，修复合并转发确认弹窗被 FullScreenModal 遮挡
- message-forward.vue 转发到当前会话时双 rAF 后触发 ON_SCROLL_BOTTOM，新消息滚动到底部
- nav-bar.vue 移除 backgroundImage: url(${title})，修复昵称/群名含非法百分号转义时进入聊天页报 URI malformed
- package.json 版本号 -> 10.3.0-alpha.2